### PR TITLE
Fix top songs heading

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,4 @@
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 
 jest.mock("nanoid", () => {
   return {

--- a/layouts/About/TopTracksList.tsx
+++ b/layouts/About/TopTracksList.tsx
@@ -11,7 +11,7 @@ export default function TopTracksList({
 }: TopTracksListProps): ReactElement | null {
   return topTracks.length > 0 ? (
     <>
-      <h2>Mi top 10 de canciones</h2>
+      <h2>Mi top {topTracks.length} de canciones</h2>
       {topTracks.map(
         ({ title, artist, songUrl, cover, uri, preview, explicit }) => (
           <MusicCard


### PR DESCRIPTION
## Summary
- adjust "TopTracksList" to display the actual number of tracks

## Testing
- `npm run test:ci` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_683f74375038832bb328ad39da4fd03c